### PR TITLE
Use a default port name of 'out' instead of '<actor name>_out'.

### DIFF
--- a/leappwf/portannotation.py
+++ b/leappwf/portannotation.py
@@ -94,11 +94,11 @@ def connectactors(actors):
                 # we do not want to have more than one output port connected to one input port
                 # break
         if ip.annotation.srcname == All:
-            names = [mp.name for mp in ip.annotation.matchports]
-            ip.annotation.linkedactor = DictionaryMerge(inport_names=names, outport_name='out')
+            namesports = {(mp.owner.name + '__' + mp.name):mp for mp in ip.annotation.matchports}
+            ip.annotation.linkedactor = DictionaryMerge(inport_names=namesports.keys(), outport_name='out')
             ip += ip.annotation.linkedactor.outports['out']
-            for mp in ip.annotation.matchports:
-                ip.annotation.linkedactor.inports[mp.name] += mp
+            for n, mp in namesports.items():
+                ip.annotation.linkedactor.inports[n] += mp
         else:
             if opcount > 1:
                 print("Warning: input port ", ip, "has {} output ports".format(opcount) )

--- a/leappwf/run.py
+++ b/leappwf/run.py
@@ -237,7 +237,7 @@ class LeAppWorkflow(object):
                                 actor_data.name)
                 return False
 
-            outport_name = actor_data.name + '_' + _OUTPORT_SUFFIX
+            outport_name = "out"
             actor_data.set_outports([{_PORT_TYPE_KEY: outport_name + '.json'}])
             self.class_factory.add_json_class(actor_data.name,
                                               port_json,


### PR DESCRIPTION
Requires a bugfix to the wildcarded actor code. The implicit DictionaryMerge
actor was getting the input port names from the output port names, leading to
the implicit requirement that output port names be unique in a workflow. Fix by
disambiguating the name by prefixing it with the actor name.